### PR TITLE
VUSB Update / gcc 4.7 fixes

### DIFF
--- a/AVR_Source/USB IR Remote Receiver 1.8/Makefile.linux
+++ b/AVR_Source/USB IR Remote Receiver 1.8/Makefile.linux
@@ -1,0 +1,49 @@
+DEVICE := atmega168
+F_CPU := 12000000UL
+
+AVRDUDE_PROGRAMMER := avrispv2
+AVRDUDE_PORT := usb
+
+AVRDUDE := avrdude -c$(AVRDUDE_PROGRAMMER) -P$(AVRDUDE_PORT) -p $(DEVICE)
+
+CC := avr-gcc
+OBJDUMP := avr-objdump
+OBJCOPY := avr-objcopy
+SIZE := avr-size
+
+CPPFLAGS := -I. -Iusbdrv/ -IIrmp/ -DF_CPU=$(F_CPU)
+CFLAGS := -Wall -Os -fpack-struct -fshort-enums -std=gnu99 -funsigned-char -funsigned-bitfields -mmcu=$(DEVICE)
+LDFLAGS := -Wl,-Map,USB_IR_Remote_Receiver.map -mmcu=$(DEVICE)
+
+OBJECTS = usbdrv/usbdrv.o usbdrv/usbdrvasm.o Irmp/irmp.o main.o
+
+PROJECT = USB_IR_Remote_Receiver
+
+.c.o:
+	$(CC) $(CPPFLAGS) $(CFLAGS) -c -o $@ $<
+
+.S.o:
+	$(CC) $(CPPFLAGS) $(CFLAGS) -x assembler-with-cpp -c -o $@ $<
+
+all: $(PROJECT).hex
+
+$(PROJECT).elf: $(OBJECTS)
+	$(CC) $(CPPFLAGS) $(CFLAGS) $(LDFLAGS) -o $(PROJECT).elf $^
+
+$(PROJECT).lss: $(PROJECT).elf
+	$(OBJDUMP) -h -S $(PROJECT).elf > $(PROJECT).lss
+
+$(PROJECT).hex: $(PROJECT).elf $(PROJECT).lss
+	$(OBJCOPY) -R .eeprom -O ihex $(PROJECT).elf $(PROJECT).hex
+
+$(PROJECT).eep: $(PROJECT).elf
+	$(OBJCOPY) -j .eeprom --no-change-warnings --change-section-lma .eeprom=0 -O ihex $(PROJECT).elf $(PROJECT).eep
+
+size: $(PROJECT).elf
+	$(SIZE) --format=berkeley -t $(PROJECT).elf
+
+flash: $(PROJECT).hex
+	$(AVRDUDE) -Uflash:w:$(PROJECT).hex:a
+
+clean:
+	$(RM) $(PROJECT).elf $(PROJECT).eep $(PROJECT).lss $(PROJECT).hex *.o $(OBJECTS)

--- a/AVR_Source/USB IR Remote Receiver 1.8/main.c
+++ b/AVR_Source/USB IR Remote Receiver 1.8/main.c
@@ -40,7 +40,7 @@ const char IrmpVersion[] = "12.03.2013";
 /* ----------------------------- USB interface ----------------------------- */
 /* ------------------------------------------------------------------------- */
 
-PROGMEM char usbHidReportDescriptor[USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH] = {
+PROGMEM const char usbHidReportDescriptor[USB_CFG_HID_REPORT_DESCRIPTOR_LENGTH] = {
     0x05, 0x01,                    // USAGE_PAGE (Generic Desktop)
     0x0b, 0x01, 0x00, 0x00, 0xff,  // USAGE (Vendor Defined Page 1:Vendor Usage 1)
     0xa1, 0x01,                    // COLLECTION (Application)

--- a/AVR_Source/USB IR Remote Receiver 1.8/main.c
+++ b/AVR_Source/USB IR Remote Receiver 1.8/main.c
@@ -132,7 +132,7 @@ static uchar    replyBuf[16];
 /* ------------------------------------------------------------------------- */
 /* main functions for irmp
  */
-void
+static void
 timer_init (void)
 {
 																			/* IR polling timer */		
@@ -153,7 +153,7 @@ timer_init (void)
  * init all io pins of the AVR, first all to input with pullups. then config USB and output pin
  *---------------------------------------------------------------------------------------------------------------------------------------------------
  */
-void 
+static void
 init_io(void) 
 {
 	/* first set all pins to input */
@@ -313,7 +313,7 @@ usbRequest_t    *rq = (void *)data;
     return 0; 
 } 
 /* ------------------------------------------------------------------------- */
-void SendINTData(void)
+static void SendINTData(void)
 {
 	
 	if (!(irmp_data.flags & IRMP_FLAG_REPETITION))											// first check if the IR command is repeated

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbconfig.h
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbconfig.h
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2005 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * This Revision: $Id: usbconfig-prototype.h 785 2010-05-30 17:57:07Z cs $
  */
 
 #ifndef __usbconfig_h_included__
@@ -280,8 +279,7 @@ section at the end of this file).
  * CDC class is 2, use subclass 2 and protocol 1 for ACM
  */
 
-
-/*#define USB_PUBLIC static */
+/* #define USB_PUBLIC static */
 /* Use the define above if you #include usbdrv.c instead of linking against it.
  * This technique saves a couple of bytes in flash memory.
  */
@@ -348,6 +346,15 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
+
+
+#define usbMsgPtr_t unsigned short
+/* If usbMsgPtr_t is not defined, it defaults to 'uchar *'. We define it to
+ * a scalar type here because gcc generates slightly shorter code for scalar
+ * arithmetics than for pointer arithmetics. Remove this define for backward
+ * type compatibility or define it to an 8 bit type if you use data in RAM only
+ * and all RAM is below 256 bytes (tiny memory model in IAR CC).
+ */
 
 /* ----------------------- Optional MCU Description ------------------------ */
 

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbconfig.h
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbconfig.h
@@ -348,7 +348,7 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
 
 
-#define usbMsgPtr_t unsigned short
+// #define usbMsgPtr_t unsigned short
 /* If usbMsgPtr_t is not defined, it defaults to 'uchar *'. We define it to
  * a scalar type here because gcc generates slightly shorter code for scalar
  * arithmetics than for pointer arithmetics. Remove this define for backward

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/Changelog.txt
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/Changelog.txt
@@ -306,3 +306,24 @@ Scroll down to the bottom to see the most recent changes.
     endpoint now.
 
 * Release 2010-07-15
+
+  - Fixed bug in usbDriverSetup() which prevented descriptor sizes above 255
+    bytes.
+  - Avoid a compiler warning for unused parameter in usbHandleResetHook() when
+    compiler option -Wextra is enabled.
+  - Fixed wrong hex value for some IDs in USB-IDs-for-free.txt.
+  - Keep a define for USBATTR_BUSPOWER, although the flag does not exist
+    in USB 1.1 any more. Set it to 0. This is for backward compatibility.
+
+* Release 2012-01-09
+
+  - Define a separate (defined) type for usbMsgPtr so that projects using a
+    tiny memory model can define it to an 8 bit type in usbconfig.h. This
+    change also saves a couple of bytes when using a scalar 16 bit type.
+  - Inserted "const" keyword for all PROGMEM declarations because new GCC
+    requires it.
+  - Fixed problem with dependence of usbportability.h on usbconfig.h. This
+    problem occurred with IAR CC only.
+  - Prepared repository for github.com.
+
+* Release 2012-12-06

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/CommercialLicense.txt
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/CommercialLicense.txt
@@ -1,5 +1,5 @@
 V-USB Driver Software License Agreement
-Version 2009-08-03
+Version 2012-07-09
 
 THIS LICENSE AGREEMENT GRANTS YOU CERTAIN RIGHTS IN A SOFTWARE. YOU CAN
 ENTER INTO THIS AGREEMENT AND ACQUIRE THE RIGHTS OUTLINED BELOW BY PAYING
@@ -37,10 +37,10 @@ Product ID(s), sent to you in e-mail. These Product IDs are reserved
 exclusively for you. OBJECTIVE DEVELOPMENT has obtained USB Product ID
 ranges under the Vendor ID 5824 from Wouter van Ooijen (Van Ooijen
 Technische Informatica, www.voti.nl) and under the Vendor ID 8352 from
-Jason Kotzin (Clay Logic, www.claylogic.com). Both owners of the Vendor IDs
-have obtained these IDs from the USB Implementers Forum, Inc.
-(www.usb.org). OBJECTIVE DEVELOPMENT disclaims all liability which might
-arise from the assignment of USB IDs.
+Jason Kotzin (now flirc.tv, Inc.). Both owners of the Vendor IDs have
+obtained these IDs from the USB Implementers Forum, Inc. (www.usb.org).
+OBJECTIVE DEVELOPMENT disclaims all liability which might arise from the
+assignment of USB IDs.
 
 2.5 USB Certification. Although not part of this agreement, we want to make
 it clear that you cannot become USB certified when you use V-USB or a USB

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/USB-ID-FAQ.txt
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/USB-ID-FAQ.txt
@@ -1,4 +1,4 @@
-Version 2009-08-22
+Version 2012-07-09
 
 ==========================
 WHY DO WE NEED THESE IDs?
@@ -107,8 +107,8 @@ WHO IS THE OWNER OF THE VENDOR-ID?
 Objective Development has obtained ranges of USB Product-IDs under two
 Vendor-IDs: Under Vendor-ID 5824 from Wouter van Ooijen (Van Ooijen
 Technische Informatica, www.voti.nl) and under Vendor-ID 8352 from Jason
-Kotzin (Clay Logic, www.claylogic.com). Both VID owners have received their
-Vendor-ID directly from usb.org.
+Kotzin (now flirc.tv, Inc.). Both VID owners have received their Vendor-ID
+directly from usb.org.
 
 
 =========================================================================

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/USB-IDs-for-free.txt
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/USB-IDs-for-free.txt
@@ -86,8 +86,9 @@ If you use one of the IDs listed below, your device and host-side software
 must conform to these rules:
 
 (1) The USB device MUST provide a textual representation of the serial
-number. The serial number string MUST be available at least in USB language
-0x0409 (English/US).
+number, unless ONLY the operating system's default class driver is used.
+The serial number string MUST be available at least in USB language 0x0409
+(English/US).
 
 (2) The serial number MUST start with either an Internet domain name (e.g.
 "mycompany.com") registered and owned by you, or an e-mail address under your
@@ -108,6 +109,11 @@ driver for Vendor Class devices is needed, this driver must be libusb or
 libusb-win32 (see http://libusb.org/ and
 http://libusb-win32.sourceforge.net/).
 
+(7) If ONLY the operating system's default class driver is used, e.g. for
+mice, keyboards, joysticks, CDC or MIDI devices and no discrimination by an
+application is needed, the serial number may be omitted.
+
+
 Table if IDs for discrimination by serial number string:
 
 PID dec (hex)  | VID dec (hex) | Description of use
@@ -121,11 +127,11 @@ PID dec (hex)  | VID dec (hex) | Description of use
 ---------------+---------------+-------------------------------------------
 10203 (0x27db) | 5824 (0x16c0) | For USB Keyboards
 ---------------+---------------+-------------------------------------------
-10204 (0x27db) | 5824 (0x16c0) | For USB Joysticks
+10204 (0x27dc) | 5824 (0x16c0) | For USB Joysticks
 ---------------+---------------+-------------------------------------------
-10205 (0x27dc) | 5824 (0x16c0) | For CDC-ACM class devices (modems)
+10205 (0x27dd) | 5824 (0x16c0) | For CDC-ACM class devices (modems)
 ---------------+---------------+-------------------------------------------
-10206 (0x27dd) | 5824 (0x16c0) | For MIDI class devices
+10206 (0x27de) | 5824 (0x16c0) | For MIDI class devices
 ---------------+---------------+-------------------------------------------
 
 

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/asmcommon.inc
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/asmcommon.inc
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2007 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * Revision: $Id$
  */
 
 /* Do not link this file! Link usbdrvasm.S instead, which includes the

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/oddebug.c
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/oddebug.c
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2005 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * This Revision: $Id: oddebug.c 692 2008-11-07 15:07:40Z cs $
  */
 
 #include "oddebug.h"

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/oddebug.h
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/oddebug.h
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2005 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * This Revision: $Id: oddebug.h 692 2008-11-07 15:07:40Z cs $
  */
 
 #ifndef __oddebug_h_included__

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbconfig-prototype.h
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbconfig-prototype.h
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2005 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * This Revision: $Id: usbconfig-prototype.h 785 2010-05-30 17:57:07Z cs $
  */
 
 #ifndef __usbconfig_h_included__
@@ -355,6 +354,15 @@ section at the end of this file).
 #define USB_CFG_DESCR_PROPS_HID                     0
 #define USB_CFG_DESCR_PROPS_HID_REPORT              0
 #define USB_CFG_DESCR_PROPS_UNKNOWN                 0
+
+
+#define usbMsgPtr_t unsigned short
+/* If usbMsgPtr_t is not defined, it defaults to 'uchar *'. We define it to
+ * a scalar type here because gcc generates slightly shorter code for scalar
+ * arithmetics than for pointer arithmetics. Remove this define for backward
+ * type compatibility or define it to an 8 bit type if you use data in RAM only
+ * and all RAM is below 256 bytes (tiny memory model in IAR CC).
+ */
 
 /* ----------------------- Optional MCU Description ------------------------ */
 

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrv.c
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrv.c
@@ -5,10 +5,8 @@
  * Tabsize: 4
  * Copyright: (c) 2005 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * This Revision: $Id: usbdrv.c 791 2010-07-15 15:56:13Z cs $
  */
 
-#include "usbportability.h"
 #include "usbdrv.h"
 #include "oddebug.h"
 
@@ -45,7 +43,7 @@ uchar       usbCurrentDataToken;/* when we check data toggling to ignore duplica
 #endif
 
 /* USB status registers / not shared with asm code */
-uchar               *usbMsgPtr;     /* data to transmit next -- ROM or RAM address */
+usbMsgPtr_t         usbMsgPtr;      /* data to transmit next -- ROM or RAM address */
 static usbMsgLen_t  usbMsgLen = USB_NO_MSG; /* remaining number of bytes */
 static uchar        usbMsgFlags;    /* flag values see below */
 
@@ -67,7 +65,7 @@ optimizing hints:
 #if USB_CFG_DESCR_PROPS_STRING_0 == 0
 #undef USB_CFG_DESCR_PROPS_STRING_0
 #define USB_CFG_DESCR_PROPS_STRING_0    sizeof(usbDescriptorString0)
-PROGMEM char usbDescriptorString0[] = { /* language descriptor */
+PROGMEM const char usbDescriptorString0[] = { /* language descriptor */
     4,          /* sizeof(usbDescriptorString0): length of descriptor in bytes */
     3,          /* descriptor type */
     0x09, 0x04, /* language index (0x0409 = US-English) */
@@ -77,7 +75,7 @@ PROGMEM char usbDescriptorString0[] = { /* language descriptor */
 #if USB_CFG_DESCR_PROPS_STRING_VENDOR == 0 && USB_CFG_VENDOR_NAME_LEN
 #undef USB_CFG_DESCR_PROPS_STRING_VENDOR
 #define USB_CFG_DESCR_PROPS_STRING_VENDOR   sizeof(usbDescriptorStringVendor)
-PROGMEM int  usbDescriptorStringVendor[] = {
+PROGMEM const int  usbDescriptorStringVendor[] = {
     USB_STRING_DESCRIPTOR_HEADER(USB_CFG_VENDOR_NAME_LEN),
     USB_CFG_VENDOR_NAME
 };
@@ -86,7 +84,7 @@ PROGMEM int  usbDescriptorStringVendor[] = {
 #if USB_CFG_DESCR_PROPS_STRING_PRODUCT == 0 && USB_CFG_DEVICE_NAME_LEN
 #undef USB_CFG_DESCR_PROPS_STRING_PRODUCT
 #define USB_CFG_DESCR_PROPS_STRING_PRODUCT   sizeof(usbDescriptorStringDevice)
-PROGMEM int  usbDescriptorStringDevice[] = {
+PROGMEM const int  usbDescriptorStringDevice[] = {
     USB_STRING_DESCRIPTOR_HEADER(USB_CFG_DEVICE_NAME_LEN),
     USB_CFG_DEVICE_NAME
 };
@@ -95,7 +93,7 @@ PROGMEM int  usbDescriptorStringDevice[] = {
 #if USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER == 0 && USB_CFG_SERIAL_NUMBER_LEN
 #undef USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER
 #define USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER    sizeof(usbDescriptorStringSerialNumber)
-PROGMEM int usbDescriptorStringSerialNumber[] = {
+PROGMEM const int usbDescriptorStringSerialNumber[] = {
     USB_STRING_DESCRIPTOR_HEADER(USB_CFG_SERIAL_NUMBER_LEN),
     USB_CFG_SERIAL_NUMBER
 };
@@ -108,7 +106,7 @@ PROGMEM int usbDescriptorStringSerialNumber[] = {
 #if USB_CFG_DESCR_PROPS_DEVICE == 0
 #undef USB_CFG_DESCR_PROPS_DEVICE
 #define USB_CFG_DESCR_PROPS_DEVICE  sizeof(usbDescriptorDevice)
-PROGMEM char usbDescriptorDevice[] = {    /* USB device descriptor */
+PROGMEM const char usbDescriptorDevice[] = {    /* USB device descriptor */
     18,         /* sizeof(usbDescriptorDevice): length of descriptor in bytes */
     USBDESCR_DEVICE,        /* descriptor type */
     0x10, 0x01,             /* USB version supported */
@@ -139,7 +137,7 @@ PROGMEM char usbDescriptorDevice[] = {    /* USB device descriptor */
 #if USB_CFG_DESCR_PROPS_CONFIGURATION == 0
 #undef USB_CFG_DESCR_PROPS_CONFIGURATION
 #define USB_CFG_DESCR_PROPS_CONFIGURATION   sizeof(usbDescriptorConfiguration)
-PROGMEM char usbDescriptorConfiguration[] = {    /* USB configuration descriptor */
+PROGMEM const char usbDescriptorConfiguration[] = {    /* USB configuration descriptor */
     9,          /* sizeof(usbDescriptorConfiguration): length of descriptor in bytes */
     USBDESCR_CONFIG,    /* descriptor type */
     18 + 7 * USB_CFG_HAVE_INTRIN_ENDPOINT + 7 * USB_CFG_HAVE_INTRIN_ENDPOINT3 +
@@ -301,7 +299,7 @@ USB_PUBLIC void usbSetInterrupt3(uchar *data, uchar len)
             len = usbFunctionDescriptor(rq);        \
         }else{                                      \
             len = USB_PROP_LENGTH(cfgProp);         \
-            usbMsgPtr = (uchar *)(staticName);      \
+            usbMsgPtr = (usbMsgPtr_t)(staticName);  \
         }                                           \
     }
 
@@ -361,7 +359,8 @@ uchar       flags = USB_FLG_MSGPTR_IS_ROM;
  */
 static inline usbMsgLen_t usbDriverSetup(usbRequest_t *rq)
 {
-uchar   len  = 0, *dataPtr = usbTxBuf + 9;  /* there are 2 bytes free space at the end of the buffer */
+usbMsgLen_t len = 0;
+uchar   *dataPtr = usbTxBuf + 9;    /* there are 2 bytes free space at the end of the buffer */
 uchar   value = rq->wValue.bytes[0];
 #if USB_CFG_IMPLEMENT_HALT
 uchar   index = rq->wIndex.bytes[0];
@@ -408,7 +407,7 @@ uchar   index = rq->wIndex.bytes[0];
     SWITCH_DEFAULT                          /* 7=SET_DESCRIPTOR, 12=SYNC_FRAME */
         /* Should we add an optional hook here? */
     SWITCH_END
-    usbMsgPtr = dataPtr;
+    usbMsgPtr = (usbMsgPtr_t)dataPtr;
 skipMsgPtrAssignment:
     return len;
 }
@@ -498,7 +497,8 @@ static uchar usbDeviceRead(uchar *data, uchar len)
         }else
 #endif
         {
-            uchar i = len, *r = usbMsgPtr;
+            uchar i = len;
+            usbMsgPtr_t r = usbMsgPtr;
             if(usbMsgFlags & USB_FLG_MSGPTR_IS_ROM){    /* ROM data */
                 do{
                     uchar c = USB_READ_FLASH(r);    /* assign to char size variable to enforce byte ops */
@@ -507,7 +507,8 @@ static uchar usbDeviceRead(uchar *data, uchar len)
                 }while(--i);
             }else{  /* RAM data */
                 do{
-                    *data++ = *r++;
+                    *data++ = *((uchar *)r);
+                    r++;
                 }while(--i);
             }
             usbMsgPtr = r;
@@ -557,6 +558,8 @@ uchar           isReset = !notResetState;
         USB_RESET_HOOK(isReset);
         wasReset = isReset;
     }
+#else
+    notResetState = notResetState;  // avoid compiler warning
 #endif
 }
 

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrv.h
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrv.h
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2005 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * This Revision: $Id: usbdrv.h 793 2010-07-15 15:58:11Z cs $
  */
 
 #ifndef __usbdrv_h_included__
@@ -122,7 +121,7 @@ USB messages, even if they address another (low-speed) device on the same bus.
 /* --------------------------- Module Interface ---------------------------- */
 /* ------------------------------------------------------------------------- */
 
-#define USBDRV_VERSION  20100715
+#define USBDRV_VERSION  20121206
 /* This define uniquely identifies a driver version. It is a decimal number
  * constructed from the driver's release date in the form YYYYMMDD. If the
  * driver's behavior or interface changes, you can use this constant to
@@ -163,6 +162,17 @@ USB messages, even if they address another (low-speed) device on the same bus.
  */
 #define USB_NO_MSG  ((usbMsgLen_t)-1)   /* constant meaning "no message" */
 
+#ifndef usbMsgPtr_t
+#define usbMsgPtr_t uchar *
+#endif
+/* Making usbMsgPtr_t a define allows the user of this library to define it to
+ * an 8 bit type on tiny devices. This reduces code size, especially if the
+ * compiler supports a tiny memory model.
+ * The type can be a pointer or scalar type, casts are made where necessary.
+ * Although it's paradoxical, Gcc 4 generates slightly better code for scalar
+ * types than for pointers.
+ */
+
 struct usbRequest;  /* forward declaration */
 
 USB_PUBLIC void usbInit(void);
@@ -178,7 +188,7 @@ USB_PUBLIC void usbPoll(void);
  * Please note that debug outputs through the UART take ~ 0.5ms per byte
  * at 19200 bps.
  */
-extern uchar *usbMsgPtr;
+extern usbMsgPtr_t usbMsgPtr;
 /* This variable may be used to pass transmit data to the driver from the
  * implementation of usbFunctionWrite(). It is also used internally by the
  * driver for standard control requests.
@@ -390,13 +400,13 @@ extern volatile schar   usbRxLen;
  * about the various methods to define USB descriptors. If you do nothing,
  * the default descriptors will be used.
  */
-#define USB_PROP_IS_DYNAMIC     (1 << 14)
+#define USB_PROP_IS_DYNAMIC     (1u << 14)
 /* If this property is set for a descriptor, usbFunctionDescriptor() will be
  * used to obtain the particular descriptor. Data directly returned via
  * usbMsgPtr are FLASH data by default, combine (OR) with USB_PROP_IS_RAM to
  * return RAM data.
  */
-#define USB_PROP_IS_RAM         (1 << 15)
+#define USB_PROP_IS_RAM         (1u << 15)
 /* If this property is set for a descriptor, the data is read from RAM
  * memory instead of Flash. The property is used for all methods to provide
  * external descriptors.
@@ -450,43 +460,43 @@ extern volatile schar   usbRxLen;
 #ifndef __ASSEMBLER__
 extern
 #if !(USB_CFG_DESCR_PROPS_DEVICE & USB_PROP_IS_RAM)
-PROGMEM
+PROGMEM const
 #endif
 char usbDescriptorDevice[];
 
 extern
 #if !(USB_CFG_DESCR_PROPS_CONFIGURATION & USB_PROP_IS_RAM)
-PROGMEM
+PROGMEM const
 #endif
 char usbDescriptorConfiguration[];
 
 extern
 #if !(USB_CFG_DESCR_PROPS_HID_REPORT & USB_PROP_IS_RAM)
-PROGMEM
+PROGMEM const
 #endif
 char usbDescriptorHidReport[];
 
 extern
 #if !(USB_CFG_DESCR_PROPS_STRING_0 & USB_PROP_IS_RAM)
-PROGMEM
+PROGMEM const
 #endif
 char usbDescriptorString0[];
 
 extern
 #if !(USB_CFG_DESCR_PROPS_STRING_VENDOR & USB_PROP_IS_RAM)
-PROGMEM
+PROGMEM const
 #endif
 int usbDescriptorStringVendor[];
 
 extern
 #if !(USB_CFG_DESCR_PROPS_STRING_PRODUCT & USB_PROP_IS_RAM)
-PROGMEM
+PROGMEM const
 #endif
 int usbDescriptorStringDevice[];
 
 extern
 #if !(USB_CFG_DESCR_PROPS_STRING_SERIAL_NUMBER & USB_PROP_IS_RAM)
-PROGMEM
+PROGMEM const
 #endif
 int usbDescriptorStringSerialNumber[];
 
@@ -719,6 +729,7 @@ typedef struct usbRequest{
 #define USBDESCR_HID_PHYS       0x23
 
 //#define USBATTR_BUSPOWER        0x80  // USB 1.1 does not define this value any more
+#define USBATTR_BUSPOWER        0
 #define USBATTR_SELFPOWER       0x40
 #define USBATTR_REMOTEWAKE      0x20
 

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm.S
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm.S
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2007 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * Revision: $Id: usbdrvasm.S 785 2010-05-30 17:57:07Z cs $
  */
 
 /*

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm.asm
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm.asm
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2006 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * This Revision: $Id$
  */
 
 /*

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm12.inc
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm12.inc
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2007 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * This Revision: $Id: usbdrvasm12.inc 740 2009-04-13 18:23:31Z cs $
  */
 
 /* Do not link this file! Link usbdrvasm.S instead, which includes the

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm128.inc
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm128.inc
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2008 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * This Revision: $Id: usbdrvasm128.inc 758 2009-08-06 10:12:54Z cs $
  */
 
 /* Do not link this file! Link usbdrvasm.S instead, which includes the

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm15.inc
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm15.inc
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2007 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * Revision: $Id: usbdrvasm15.inc 740 2009-04-13 18:23:31Z cs $
  */
 
 /* Do not link this file! Link usbdrvasm.S instead, which includes the

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm16.inc
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm16.inc
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2007 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * Revision: $Id: usbdrvasm16.inc 760 2009-08-09 18:59:43Z cs $
  */
 
 /* Do not link this file! Link usbdrvasm.S instead, which includes the

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm165.inc
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm165.inc
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2007 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * Revision: $Id: usbdrvasm165.inc 740 2009-04-13 18:23:31Z cs $
  */
 
 /* Do not link this file! Link usbdrvasm.S instead, which includes the

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm18-crc.inc
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm18-crc.inc
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2008 by Lukas Schrittwieser and OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * Revision: $Id: usbdrvasm18-crc.inc 740 2009-04-13 18:23:31Z cs $
  */
 
 /* Do not link this file! Link usbdrvasm.S instead, which includes the

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm20.inc
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbdrvasm20.inc
@@ -6,7 +6,6 @@
  * Tabsize: 4
  * Copyright: (c) 2008 by Jeroen Benschop and OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * Revision: $Id: usbdrvasm20.inc 740 2009-04-13 18:23:31Z cs $
  */
 
 /* Do not link this file! Link usbdrvasm.S instead, which includes the

--- a/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbportability.h
+++ b/AVR_Source/USB IR Remote Receiver 1.8/usbdrv/usbportability.h
@@ -5,7 +5,6 @@
  * Tabsize: 4
  * Copyright: (c) 2008 by OBJECTIVE DEVELOPMENT Software GmbH
  * License: GNU GPL v2 (see License.txt), GNU GPL v3 or proprietary (CommercialLicense.txt)
- * This Revision: $Id: usbportability.h 785 2010-05-30 17:57:07Z cs $
  */
 
 /*


### PR DESCRIPTION
The VUSB update was necessary to be able to compile it with gcc 4.7.
I also made some functions static to safe some bytes.
